### PR TITLE
Add halo update to correct problem in the CIOD

### DIFF
--- a/src/SIS_dyn_trans.F90
+++ b/src/SIS_dyn_trans.F90
@@ -1007,6 +1007,8 @@ subroutine SIS_merged_dyn_cont(OSS, FIA, IOF, DS2d, IST, dt_cycle, Time_start, G
 !        call hchksum_pair("WindStr_[xy]_A before SIS_C_dynamics", WindStr_x_A, WindStr_y_A, G, halos=1)
       endif
 
+      call pass_var(DS2d%mca_step(:,:,DS2d%n_ts), G%Domain, complete=.true.)          
+
       call cpu_clock_begin(iceClocka)
       !### Ridging needs to be added with C-grid dynamics.
       if (CS%do_ridging) rdg_rate(:,:) = 0.0


### PR DESCRIPTION
Added a halo update of the sea-ice and snow mass before SIS_C_dynamics Currently it is called every time step, but that may be too often.